### PR TITLE
add localhost for easier testing to docker-compose.env.tpl

### DIFF
--- a/docker-compose.env.tpl
+++ b/docker-compose.env.tpl
@@ -1,5 +1,5 @@
 # Caddy settings:
-BASE_URL=http://127.0.0.1
+BASE_URL=localhost, 127.0.0.1
 APP_PATH=/api
 
 # TOP Framework related settings:


### PR DESCRIPTION
Caddy doesn't equate 127.0.0.1 with localhost, so without this there won't be any result when accessing "localhost".