### PR TITLE
remove deprecated Docker Compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   db:
     image: postgres:15


### PR DESCRIPTION
It is recommended to not specify a version in `docker-compose.yml` anymore.
See <https://docs.docker.com/compose/compose-file/compose-versioning/>.

> The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative.