### PR TITLE
fix local Jekyll docs preview

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+_site

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+gem "just-the-docs"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,5 @@
 remote_theme: just-the-docs/just-the-docs
+theme: just-the-docs
 color_scheme: top
 title: TOP Framework
 description: Terminology- and Ontology-based Phenotyping Framework
@@ -28,3 +29,9 @@ compress_html:
   startings: []
   blanklines: false
   profile: false
+
+defaults:
+  - scope:
+      path: "**/*.md"
+    values:
+      layout: "page"


### PR DESCRIPTION
The documentation theme works fine when automatically served via GitHub pages but there is no styling at all when previewing it locally using "jekyll serve" or "bundle exec jekyll serve".
This PR adds the necessary Gemfile and configuration options to enable local preview including the theme.
I do not expect this to change GitHub pages display.