### PR TITLE
update EMBL-EBI API URL

### DIFF
--- a/docker-compose.env.tpl
+++ b/docker-compose.env.tpl
@@ -33,7 +33,7 @@ QUERY_RESULT_DIR=/data/query_results
 
 # The backend can query terms from an OLS (v3) instance. The API endpoint of that instance is configured
 # with TERMINOLOGY_SERVICE_ENDPOINT
-TERMINOLOGY_SERVICE_ENDPOINT=https://www.ebi.ac.uk/ols/api
+TERMINOLOGY_SERVICE_ENDPOINT=https://www.ebi.ac.uk/ols4/api
 
 # If you want the frontend to show a GDPR conform cookie notification, you can set the variable
 # GDPR_NOTICE to true. Users can accept the notification and it will not be displayed until cookies

--- a/docker-compose.env.tpl
+++ b/docker-compose.env.tpl
@@ -31,7 +31,7 @@ DATA_SOURCE_CONFIG_DIR=/configs
 # stored as ZIP files.
 QUERY_RESULT_DIR=/data/query_results
 
-# The backend can query terms from an OLS (v3) instance. The API endpoint of that instance is configured
+# The backend can query terms from an OLS (v4) instance. The API endpoint of that instance is configured
 # with TERMINOLOGY_SERVICE_ENDPOINT
 TERMINOLOGY_SERVICE_ENDPOINT=https://www.ebi.ac.uk/ols4/api
 


### PR DESCRIPTION
Follow the redirect to the new EMBL-EBI OLS4 API URL.
Please check before merging if it actually works with OLS4, as I don't know what the expected behavior is.
P.S.: The two commits can be squashed, I just changed v3 to v4 in the comment.